### PR TITLE
ci: install FoundationDB client package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,11 @@ jobs:
       with:
         go-version: '1.23'
 
+    - name: Install FoundationDB client
+      run: |
+        curl -LO https://github.com/apple/foundationdb/releases/download/7.3.43/foundationdb-clients_7.3.43-1_amd64.deb
+        sudo dpkg -i foundationdb-clients_7.3.43-1_amd64.deb
+
     - name: Build
       run: go build -v ./...
 


### PR DESCRIPTION
The FDB Go bindings use CGo and require fdb_c.h from the FoundationDB client package. Install it before build/test steps.